### PR TITLE
[debian] Depend on ofono-config-ril-binder-single-sim-sim2

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,6 +14,7 @@ Depends: ${misc:Depends},
          adaptation-lavender-configs,
          linux-bootimage-xiaomi-lavender,
          batman,
+         ofono-config-ril-binder-single-sim-sim2,
 Description: adapatation-lavender-meta
  lavender api28 adaptation metapackage
 


### PR DESCRIPTION
This allows the use of SIM2 instead of SIM1. SIM1 is hybrid slot for SD-cards and we don't want to block using SD-cards